### PR TITLE
Fix display of tasks

### DIFF
--- a/pages/partials/todolist.php
+++ b/pages/partials/todolist.php
@@ -65,7 +65,7 @@ if (!access_has_global_level(plugin_config_get('view_threshold'))) return;
         confirmDeletion: "<?= plugin_lang_get('confirm_deletion') ?>",
       });
       <?php if ($tasks): ?>
-      window.onload = () => {
+      window.onload = function() {
         this.ToDoList.$set("tasks", <?= json_encode($tasks) ?>);
       };
       <?php endif; ?>


### PR DESCRIPTION
This likely got broken in the change that added Mantis 2.0
compatibility. A Javascript lambda does not have access to `this`,
so this needs to be a regular function again.